### PR TITLE
[python] achieve PEP8 conformity

### DIFF
--- a/python/compactmessageformat.py
+++ b/python/compactmessageformat.py
@@ -14,13 +14,21 @@
 
 import codecs
 
+
 class CMF_ValueType:
-    PositiveNumber = 0, # var-int-encoded (between 1 and 9 bytes in length). Per definition a positive number.
-    NegativeNumber = 1, # var-int-encoded (between 1 and 9 bytes in length). Per definition a negative number.
-    String = 2,         # first an UnsignedNumber for the length, then the actual bytes. Never a closing zero. Utf8 encoded.
+    # var-int-encoded (between 1 and 9 bytes in length).
+    # Per definition a positive number.
+    PositiveNumber = 0,
+    # var-int-encoded (between 1 and 9 bytes in length).
+    # Per definition a negative number.
+    NegativeNumber = 1,
+    # first an UnsignedNumber for the length, then the actual bytes.
+    # Never a closing zero. Utf8 encoded.
+    String = 2,
     ByteArray = 3,      # identical to String, but without encoding.
     BoolTrue = 4,       # not followed with any bytes
     BoolFalse = 5       # not followed with any bytes
+
 
 def serialize(data, offset, value):
     pos = 0
@@ -61,6 +69,7 @@ def unserialize(data, dataSize, position):
             return position, result
     raise Exception("Reading VarInt past stream-size")
 
+
 def arraycopy(source, sourcePos, dest, destPos, numElem):
     while (numElem > 0):
         dest[destPos] = source[sourcePos]
@@ -75,52 +84,55 @@ def arraycopy(source, sourcePos, dest, destPos, numElem):
 
   The unique part is that the value is typed and for variable-length structures
   (like a string) a length is included.
-  The effect is that you can fully parse a structure without having any prior knowledge
-  of the fields, the expected content in the fields and the size.
-  You can compare this to an XML stream where some items are stored with tags or attributes
-  are unknown to the reader, without causing any effect on being able to parse them or to write
-  them out again unchanged.
+  The effect is that you can fully parse a structure without having any prior
+  knowledge of the fields, the expected content in the fields and the size.
+  You can compare this to an XML stream where some items are stored with tags
+  or attributes are unknown to the reader, without causing any effect on being
+  able to parse them or to write them out again unchanged.
 """
+
+
 class MessageBuilder:
+
     def __init__(self, data, position):
         self.buffer = data
         self.position = position
 
     def add_int(self, tag, value):
         if (value >= 0):
-            vt = 0 # PositiveNumber
+            vt = 0  # PositiveNumber
         else:
-            vt = 1 # NegativeNumber
+            vt = 1  # NegativeNumber
             value *= -1
         self.__write(tag, vt)
         self.position += serialize(self.buffer, self.position, value)
 
     # This method assumes that 'value' is already an utf8 encoded string.
     def add_string(self, tag, value):
-        self.__write(tag, 2) # String
-        bytesData = codecs.encode(value, 'utf-8');
+        self.__write(tag, 2)  # String
+        bytesData = codecs.encode(value, 'utf-8')
         self.position += serialize(self.buffer, self.position, len(bytesData))
         arraycopy(bytesData, 0, self.buffer, self.position, len(bytesData))
         self.position += len(bytesData)
 
     def add_bytes(self, tag, value):
-        self.__write(tag, 3) # bytearray
+        self.__write(tag, 3)  # bytearray
         self.position += serialize(self.buffer, self.position, len(value))
         arraycopy(value, 0, self.buffer, self.position, len(value))
         self.position += len(value)
 
     def add_bool(self, tag, value):
-        type = 5 # Bool_False
-        if (value == True):
-            type = 4 # Bool_True
+        type = 5  # Bool_False
+        if value is True:
+            type = 4  # Bool_True
         self.__write(tag, type)
 
     def get_position(self):
         return self.position
 
     def __write(self, tag, type):
-        if (tag >= 31): # use more than 1 byte
-            byte = type | 0xF8 # set the 'tag' to all 1s
+        if (tag >= 31):  # use more than 1 byte
+            byte = type | 0xF8  # set the 'tag' to all 1s
             self.buffer[self.position] = byte
             self.position += serialize(self.buffer, self.position + 1, tag) + 1
             return
@@ -131,7 +143,9 @@ class MessageBuilder:
         self.buffer[self.position] = byte
         self.position = self.position + 1
 
+
 class MessageParser(object):
+
     def __init__(self, data, position, length):
         self.data = data
         self.position = position
@@ -162,7 +176,8 @@ class MessageParser(object):
         if (self.tag == 31):  # the tag is stored in the next byte(s)
             newTag = 0
             self.position += 1
-            self.position, newTag = unserialize(self.data, self.endPosition, self.position)
+            self.position, newTag = unserialize(
+                self.data, self.endPosition, self.position)
             ok = True
             if (ok and newTag > 0xFFFF):
                 ok = False
@@ -172,18 +187,20 @@ class MessageParser(object):
             self.tag = newTag
 
         value = 0
-        if (data_type == 0 or data_type == 1): # Numbers
-            self.position, value = unserialize(self.data, self.endPosition, self.position + 1)
-            if (data_type == 1): # CMF_ValueType.NegativeNumber
+        if (data_type == 0 or data_type == 1):  # Numbers
+            self.position, value = unserialize(
+                self.data, self.endPosition, self.position + 1)
+            if (data_type == 1):  # CMF_ValueType.NegativeNumber
                 value *= -1
             self.value = value
-        elif (data_type == 2 or data_type == 3): # String or ByteArray
+        elif (data_type == 2 or data_type == 3):  # String or ByteArray
             newPos = self.position + 1
             newPos, value = unserialize(self.data, self.endPosition, newPos)
-            if (newPos + value > len(self.data)): # need more bytes
+            if (newPos + value > len(self.data)):  # need more bytes
                 return MessageParser.Type.Error
 
-            self.valueState = MessageParser.Lazy.ByteArray if (data_type == 3) else MessageParser.Lazy.String
+            self.valueState = MessageParser.Lazy.ByteArray if (
+                data_type == 3) else MessageParser.Lazy.String
             self.dataStart = newPos
             self.dataLength = value
             self.position = newPos + value
@@ -200,7 +217,8 @@ class MessageParser(object):
         return MessageParser.Type.FoundTag
 
     def string_value(self):
-        if (self.valueState == MessageParser.Lazy.ByteArray or self.valueState == MessageParser.Lazy.String):
+        if (self.valueState == MessageParser.Lazy.ByteArray or
+                self.valueState == MessageParser.Lazy.String):
             return self.data[self.dataStart:self.dataStart + self.dataLength]
         return self.value
 
@@ -210,5 +228,3 @@ class MessageParser(object):
     def consume(self, num_bytes):
         assert(num_bytes >= 0)
         self.position += num_bytes
-
-

--- a/python/runtests.py
+++ b/python/runtests.py
@@ -29,11 +29,11 @@ class TestCMF(unittest.TestCase):
         self.assertEqual(buffer[1], 177)
         self.assertEqual(buffer[2], 112)
 
-        parser = MessageParser(buffer, 0, 3);
-        self.assertEquals(MessageParser.Type.FoundTag, parser.next());
-        self.assertEquals(15, parser.tag);
-        self.assertEquals(6512, parser.value);
-        self.assertEquals(MessageParser.Type.EndOfDocument, parser.next());
+        parser = MessageParser(buffer, 0, 3)
+        self.assertEquals(MessageParser.Type.FoundTag, parser.next())
+        self.assertEquals(15, parser.tag)
+        self.assertEquals(6512, parser.value)
+        self.assertEquals(MessageParser.Type.EndOfDocument, parser.next())
 
     def test_basic2(self):
         buffer = bytearray(b"000000000000000000000000000000000")
@@ -46,24 +46,24 @@ class TestCMF(unittest.TestCase):
         self.assertEqual(buffer[3], 177)
         self.assertEqual(buffer[4], 112)
 
-        parser = MessageParser(buffer, 0, 5);
-        self.assertEquals(MessageParser.Type.FoundTag, parser.next());
-        self.assertEquals(129, parser.tag);
-        self.assertEquals(6512, parser.value);
-        self.assertEquals(MessageParser.Type.EndOfDocument, parser.next());
+        parser = MessageParser(buffer, 0, 5)
+        self.assertEquals(MessageParser.Type.FoundTag, parser.next())
+        self.assertEquals(129, parser.tag)
+        self.assertEquals(6512, parser.value)
+        self.assertEquals(MessageParser.Type.EndOfDocument, parser.next())
 
     def test_types(self):
         buffer = bytearray(b"000000000000000000000000000000000")
         builder = MessageBuilder(buffer, 0)
-        builder.add_string(1, u"Föo");
-        builder.add_bytes(200, b"hihi");
-        builder.add_bool(3, True);
-        builder.add_bool(40, False);
+        builder.add_string(1, u"Föo")
+        builder.add_bytes(200, b"hihi")
+        builder.add_bool(3, True)
+        builder.add_bool(40, False)
         self.assertEqual(builder.get_position(), 17)
 
         # string '1'
         self.assertEquals(buffer[0], 10)
-        self.assertEquals(buffer[1], 4) # serialized string length
+        self.assertEquals(buffer[1], 4)  # serialized string length
         self.assertEquals(buffer[2], 70)
         self.assertEquals(buffer[3], 195)
         self.assertEquals(buffer[4], 182)
@@ -73,34 +73,33 @@ class TestCMF(unittest.TestCase):
         self.assertEquals(buffer[6], 251)
         self.assertEquals(buffer[7], 128)
         self.assertEquals(buffer[8], 72)
-        self.assertEquals(buffer[9], 4) #length of bytearray
-        self.assertEquals(buffer[10], 104) # 'h'
-        self.assertEquals(buffer[11], 105) # 'i'
-        self.assertEquals(buffer[12], 104) # 'h'
-        self.assertEquals(buffer[13], 105) # 'i'
+        self.assertEquals(buffer[9], 4)  # length of bytearray
+        self.assertEquals(buffer[10], 104)  # 'h'
+        self.assertEquals(buffer[11], 105)  # 'i'
+        self.assertEquals(buffer[12], 104)  # 'h'
+        self.assertEquals(buffer[13], 105)  # 'i'
 
         # bool-true '3'
-        self.assertEquals(buffer[14], 28);
+        self.assertEquals(buffer[14], 28)
 
         # bool-false '40'
-        self.assertEquals(buffer[15], 253);
-        self.assertEquals(buffer[16], 40);
+        self.assertEquals(buffer[15], 253)
+        self.assertEquals(buffer[16], 40)
 
-        parser = MessageParser(buffer, 0, builder.get_position());
-        self.assertEquals(MessageParser.Type.FoundTag, parser.next());
-        self.assertEquals(1, parser.tag);
+        parser = MessageParser(buffer, 0, builder.get_position())
+        self.assertEquals(MessageParser.Type.FoundTag, parser.next())
+        self.assertEquals(1, parser.tag)
         self.assertEquals(u"Föo".encode('utf-8'), parser.string_value())
-        self.assertEquals(MessageParser.Type.FoundTag, parser.next());
-        self.assertEquals(200, parser.tag);
+        self.assertEquals(MessageParser.Type.FoundTag, parser.next())
+        self.assertEquals(200, parser.tag)
         self.assertEquals(b"hihi", parser.string_value())
-        self.assertEquals(MessageParser.Type.FoundTag, parser.next());
-        self.assertEquals(3, parser.tag);
+        self.assertEquals(MessageParser.Type.FoundTag, parser.next())
+        self.assertEquals(3, parser.tag)
         self.assertEquals(True, parser.value)
-        self.assertEquals(MessageParser.Type.FoundTag, parser.next());
-        self.assertEquals(40, parser.tag);
+        self.assertEquals(MessageParser.Type.FoundTag, parser.next())
+        self.assertEquals(40, parser.tag)
         self.assertEquals(False, parser.value)
-        self.assertEquals(MessageParser.Type.EndOfDocument, parser.next());
+        self.assertEquals(MessageParser.Type.EndOfDocument, parser.next())
 
 if __name__ == '__main__':
     unittest.main()
-


### PR DESCRIPTION
Best to get this out the way early so we can stay PEP8 compliant.
Both Python files are now PEP8 clean, which should help avoid the ire of Python programmers :-)

Tools used: `pep8`, `autopep8` (available through `pip install` on most friendly distros near you)

Helpful IDEs will check PEP8 compliance while you code (e.g. Eclipse PyDev - nice and free).